### PR TITLE
Additional use of `self.dim`

### DIFF
--- a/pyro/distributions/transforms/permute.py
+++ b/pyro/distributions/transforms/permute.py
@@ -94,7 +94,7 @@ class Permute(Transform):
         determinant is -1 or +1), and so returning a vector of zeros works.
         """
 
-        return torch.zeros(x.size()[:-1], dtype=x.dtype, layout=x.layout, device=x.device)
+        return torch.zeros(x.size()[:-self.event_dim], dtype=x.dtype, layout=x.layout, device=x.device)
 
 
 def permute(input_dim, permutation=None):


### PR DESCRIPTION
We need to take `self.dim` into account at the end of `_call`, `_inverse`, and `log_abs_det_jacobian`.

As a clarification, the changes to `log_abs_det_jacobian` are needed to perform an "elementwise" summation, where the elements are the samples/batches. This ensures that the transform works with things like `TransformedDistribution` that use the transform's `event_dim` to sum log probabilities from different transformations.